### PR TITLE
Make QR-Code square again!

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/service/encoder/LightCertificateBarcodeCreator.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/service/encoder/LightCertificateBarcodeCreator.java
@@ -9,8 +9,6 @@ package ch.admin.bag.covidcertificate.service.encoder;
 import com.google.common.base.Charsets;
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
-import com.google.zxing.client.j2se.MatrixToImageWriter;
-import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import com.google.zxing.qrcode.encoder.ByteMatrix;
 import com.google.zxing.qrcode.encoder.Encoder;
@@ -58,7 +56,7 @@ public class LightCertificateBarcodeCreator implements BarcodeCreator {
         final Map<EncodeHintType, Object> encodingHints = new HashMap<>();
         encodingHints.put(EncodeHintType.CHARACTER_SET, characterSet);
         try {
-            QRCode code = Encoder.encode(contents, ErrorCorrectionLevel.Q, encodingHints);
+            QRCode code = Encoder.encode(contents, ErrorCorrectionLevel.M, encodingHints);
             BufferedImage image = renderQRImage(code, DEFAULT_WIDTH_AND_HEIGHT, DEFAULT_WIDTH_AND_HEIGHT, 4);
 
             byte[] bytes = bufferedImageToBytes(image);
@@ -120,8 +118,6 @@ public class LightCertificateBarcodeCreator implements BarcodeCreator {
         int leftPadding = (outputWidth - (inputWidth * multiple)) / 2;
         int topPadding = (outputHeight - (inputHeight * multiple)) / 2;
         final int FINDER_PATTERN_SIZE = 7;
-        final float CIRCLE_SCALE_DOWN_FACTOR = 28f / 30f;
-        int circleSize = (int) (multiple * CIRCLE_SCALE_DOWN_FACTOR);
 
         for (int inputY = 0, outputY = topPadding; inputY < inputHeight; inputY++, outputY += multiple) {
             for (int inputX = 0, outputX = leftPadding; inputX < inputWidth; inputX++, outputX += multiple) {
@@ -129,37 +125,38 @@ public class LightCertificateBarcodeCreator implements BarcodeCreator {
                     if (!(inputX <= FINDER_PATTERN_SIZE && inputY <= FINDER_PATTERN_SIZE
                             || inputX >= inputWidth - FINDER_PATTERN_SIZE && inputY <= FINDER_PATTERN_SIZE
                             || inputX <= FINDER_PATTERN_SIZE && inputY >= inputHeight - FINDER_PATTERN_SIZE)) {
-                        // graphics.fillRoundRect(outputX, outputY, circleSize, circleSize, (int)(round*circleSize), (int)(round*3));
-                        graphics.fillOval(outputX, outputY, circleSize, circleSize);
+                        graphics.fillRect(outputX, outputY, multiple, multiple);
                     }
                 }
             }
         }
 
-        int circleDiameter = multiple * FINDER_PATTERN_SIZE;
-        drawFinderPatternCircleStyle(graphics, leftPadding, topPadding, circleDiameter);
-        drawFinderPatternCircleStyle(graphics, leftPadding + (inputWidth - FINDER_PATTERN_SIZE) * multiple, topPadding,
-                circleDiameter);
-        drawFinderPatternCircleStyle(graphics, leftPadding, topPadding + (inputHeight - FINDER_PATTERN_SIZE) * multiple,
-                circleDiameter);
+        int finderSideLength = multiple * FINDER_PATTERN_SIZE;
+
+        drawFinderPatternRectangleStyle(graphics, leftPadding, topPadding,
+        finderSideLength);
+        drawFinderPatternRectangleStyle(graphics, leftPadding + (inputWidth -
+        FINDER_PATTERN_SIZE) * multiple, topPadding,
+        finderSideLength);
+        drawFinderPatternRectangleStyle(graphics, leftPadding, topPadding + (inputHeight
+        - FINDER_PATTERN_SIZE) * multiple,
+        finderSideLength);
 
         return image;
     }
 
-    static final float round = 0.6f;
-
-    private static void drawFinderPatternCircleStyle(Graphics2D graphics, int x, int y, int circleDiameter) {
-        final int WHITE_CIRCLE_DIAMETER = circleDiameter * 5 / 7;
-        final int WHITE_CIRCLE_OFFSET = circleDiameter / 7;
-        final int MIDDLE_DOT_DIAMETER = circleDiameter * 3 / 7;
-        final int MIDDLE_DOT_OFFSET = circleDiameter * 2 / 7;
+    private static void drawFinderPatternRectangleStyle(Graphics2D graphics, int x, int y, int sideLength) {
+        final int OUTER_FINDER_SIDE_LENGTH = sideLength * 5 / 7;
+        final int OUTER_FINDER_OFFSET = sideLength / 7;
+        final int INNTER_FINDER_SIDE_LENGTH = sideLength * 3 / 7;
+        final int INNER_FINDER_OFFSET = sideLength * 2 / 7;
 
         graphics.setColor(lightBlue);
-        graphics.fillOval(x, y, circleDiameter, circleDiameter);
+        graphics.fillRect(x, y, sideLength, sideLength);
         graphics.setColor(Color.white);
-        graphics.fillOval(x + WHITE_CIRCLE_OFFSET, y + WHITE_CIRCLE_OFFSET, WHITE_CIRCLE_DIAMETER,
-                WHITE_CIRCLE_DIAMETER);
+        graphics.fillRect(x + OUTER_FINDER_OFFSET, y + OUTER_FINDER_OFFSET, OUTER_FINDER_SIDE_LENGTH,
+                OUTER_FINDER_SIDE_LENGTH);
         graphics.setColor(darkBlue);
-        graphics.fillOval(x + MIDDLE_DOT_OFFSET, y + MIDDLE_DOT_OFFSET, MIDDLE_DOT_DIAMETER, MIDDLE_DOT_DIAMETER);
+        graphics.fillRect(x + INNER_FINDER_OFFSET, y + INNER_FINDER_OFFSET, INNTER_FINDER_SIDE_LENGTH, INNTER_FINDER_SIDE_LENGTH);
     }
 }

--- a/src/test/java/ch/admin/bag/covidcertificate/lightcert/TestLightCert.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/lightcert/TestLightCert.java
@@ -1,0 +1,23 @@
+package ch.admin.bag.covidcertificate.lightcert;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import ch.admin.bag.covidcertificate.service.encoder.LightCertificateBarcodeCreator;
+import se.digg.dgc.encoding.BarcodeException;
+
+@Disabled("creates local file with barcode")
+public class TestLightCert {
+    @Test
+    public void makeQrCode() throws BarcodeException, IOException {
+        var barcode = new LightCertificateBarcodeCreator().create(
+                "HC1:NCFM60BG0/3WUWGSLKH47GO0SY8T$TF:GUD39CK/500XK0JCV497F3YM2:FV3F38DA5HVY50.FK6ZK7:EDOLOPCO8F6%E3.DA%EOPC1G72A6YM8KG7DB8ES8457SM8GS8BA6DB80G6D46$96RW6SG6UPC0JCZ69FVCPD0LVC6JD846Y96F465W5307+EDG8F3I80/D6$CBECSUER:C2$NS346$C2%E9VC- CSUE145GB8JA5B$D% D3IA4W5646846C46IA7.JCN9E.G8YB956ASN8KKE3KC.SC4KCD3DX47B46IL6646H*6Z/ER2DD46JH8946JPCT3E6JD846Y96F463W5407..DX%DZJC7/DUOA5$C6LEA/D33D.A6I3DYUC6$C5WEW.CDWE/NAGY8HIAL+9B09/A6I3D6WEITA2OA$PC5$CUZC$$5Y$5FBB%10GVN +DCUL *VD4Q43P3DF3.GQ-0T7F7DKYHCECHP 5KUDRVMFIJQBTH*C$XNQWIIJ2M*6  HGPP3OQQ/40%P4*T7.2PVPTAW:V7N52$D0/EG9 MJB80R1U282GRIQL%9UR3TX-1UHPZUQ2NS4SAY D88SML7MUKI 28L7:SOKLE.XT4.0BX2JUPM:6:2T/696GQ2R9R:POTB%MA7TLCCM8-F3*AT$GO$E6622EN/KHJF4IX8%5PP07/B4H2WRNE+QBDB483G P56I7R73VS8SI9XFT01DLBESSFDBM3RE67Q+31.QN. N%6H0$GWIF2KU3THJI30SV2EOB3I0V80-23ID92I.PC7R5Y1WN7N-DCA8HT6RTQODE61V1BV827BH9K24");
+
+        FileOutputStream outputStream = new FileOutputStream("code.png");
+        outputStream.write(barcode.getImage());
+        outputStream.close();
+    }
+}


### PR DESCRIPTION
QR-Codes with round Capstones cannot be read by certain QR-Code readers, hence we go back to square ones.

Further, to reduce QR-Code-Size we reduce the error correction level from Q to M.